### PR TITLE
'force' flag changed to 'break_on_exceptions'

### DIFF
--- a/src/puzzle2/Puzzle.py
+++ b/src/puzzle2/Puzzle.py
@@ -162,9 +162,9 @@ class Puzzle(object):
          0: Success
          1: Error
          2: Skipped
-         3: Task stopped
-         4: module import error/ traceback error
-         5: require key is not exists
+         3: Break
+         4: Module import error/ traceback error
+         5: Required key does not exist
         """
         def _execute_step(tasks, data, common, step, response):
             """
@@ -207,10 +207,11 @@ class Puzzle(object):
                                              data=data,
                                              data_globals=response.get("data_globals", {}))
 
-                    # default, do not stop when script had error.
-                    # if we want to stop tasks, set force key to task setting.
-                    force = task.get("force", False)
-                    if response.get("return_code", 0) > 0 and force:
+                    # Rest of the pipeline tasks will be skipped when
+                    # 1. break_on_exceptions is set to TRUE
+                    # 2. Exceptions (return flags 1,3,4,5) are caught through return_code
+                    break_on_exceptions = task.get("break_on_exceptions", False)
+                    if response.get("return_code", 0) not in [0, 2] and break_on_exceptions:
                         self.break_ = True
                         self.logger.debug("set break: True")
                         break

--- a/src/puzzle2/PzTask.py
+++ b/src/puzzle2/PzTask.py
@@ -25,9 +25,9 @@ class PzTask(object):
          0: Success
          1: Error
          2: Skipped
-         3: Task stopped
-         4: module import error
-         5: require key is not exists
+         3: Break
+         4: Module import error
+         5: Required key does not exist
         """
         self.task.setdefault("name", "untitled")
         self.name = self.task["name"]

--- a/tests/src/win/test_puzzle.py
+++ b/tests/src/win/test_puzzle.py
@@ -323,7 +323,7 @@ class PuzzleTest(unittest.TestCase):
         self.puzzle.play(tasks, data)
 
         return_codes = self.puzzle.logger.details.get_return_codes()
-        self.assertEqual([2, 2, 4], return_codes)
+        self.assertEqual([2, 2, 4, 4], return_codes)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/win/test_puzzle.py
+++ b/tests/src/win/test_puzzle.py
@@ -53,13 +53,13 @@ class PuzzleTestAndTutorial(unittest.TestCase):
 
     def test_task_failed_then_stopped(self):
         """
-        there are error and force key exists.
+        there are error and break_on_exceptions key exists.
         tasks stopped.
         """
         print("")
         print("test_task_failed_then_stopped")
 
-        tasks = {"pre": [{"module": "tasks.win.open_file", "force": True}],
+        tasks = {"pre": [{"module": "tasks.win.open_file", "break_on_exceptions": True}],
                  "main": [{"module": "tasks.win.export_file"}]}
         
         data = {"pre": {"path": "somewhere"}, 
@@ -72,7 +72,7 @@ class PuzzleTestAndTutorial(unittest.TestCase):
 
     def test_task_failed_stop_but_closure_is_executed(self):
         """
-        there are error and force key exists.
+        there are error and break_on_exceptions key exists.
         tasks stopped.
         but special step "closure" will executed.
         sometime, closere data will generate inside other tasks.
@@ -81,7 +81,7 @@ class PuzzleTestAndTutorial(unittest.TestCase):
         print("")
         print("test_task_failed_stop_but_closure_is_executed")
 
-        tasks = {"pre": [{"module": "tasks.win.open_file", "force": True}],
+        tasks = {"pre": [{"module": "tasks.win.open_file", "break_on_exceptions": True}],
                  "main": [{"module": "tasks.win.export_file"}], 
                  "closure": [{"module": "tasks.win.revert"}]}
         
@@ -126,7 +126,7 @@ class PuzzleTestAndTutorial(unittest.TestCase):
         """
         print("")
         print("test_import_and_rename_and_export")
-        tasks = {"pre": [{"module": "tasks.win.open_file", "force": True}],
+        tasks = {"pre": [{"module": "tasks.win.open_file", "break_on_exceptions": True}],
                  "main": [{"module": "tasks.win.import_file"}, 
                           {"module": "tasks.win.rename_namespace"}, 
                           {"module": "tasks.win.export_file", 


### PR DESCRIPTION
'force' -> 'break_on_exceptions' フラグに変更

追加提案メモ：

ReturnCodeを定数とし、どこかで constants.py にまとめたい（覚えられないので。。）。
「4」が重複しているのも今後分けたい（taMayaBatcherでは別検出予定）
```
RETURNCODE_UNSTARTED = -1
RETURNCODE_SUCCESS = 0
RETURNCODE_ERROR = 1
RETURNCODE_SKIPPED = 2
RETURNCODE_BREAK = 3
RETURNCODE_MODULE_FUNC_MISSING = 4
RETURNCODE_MODULE_IMPORT_ERROR = 4
RETURNCODE_MODULE_NOT_FOUND = 4
RETURNCODE_REQUIRED_KEY_NOT_FOUND = 5
```