### PR TITLE
Wrap os.makedirs() with try-except to skip unnecessary error

### DIFF
--- a/src/puzzle2/PzLog.py
+++ b/src/puzzle2/PzLog.py
@@ -44,12 +44,12 @@ class Details(object):
         self.order.append(self.name)
 
         self.index += 1
-    
+
     def add_detail(self, text):
         self._details.setdefault(self.name, []).append(text)
-    
+
     def set_header(self, return_code, text):
-        self._header[self.name] = {"return_code": return_code, 
+        self._header[self.name] = {"return_code": return_code,
                                    "header": text}
 
     def update_code(self, return_code):
@@ -86,9 +86,9 @@ class Details(object):
                 data["details"] = self._details[name]
 
             all_.append(data)
-        
+
         return all_
-    
+
     def clear(self):
         self._header = {}
         self._details = {}
@@ -290,8 +290,12 @@ class PzLog(object):
                     return w.replace(k, v)
             return w
 
-        if not os.path.exists(os.path.dirname(self.config_path)):
-            os.makedirs(os.path.dirname(self.config_path))
+        if not os.path.isdir(os.path.dirname(self.config_path)):
+            try:
+                os.makedirs(os.path.dirname(self.config_path))
+            except BaseException:  # Dir is created between the os.path.isdir and the os.makedirs calls
+                if not os.path.isdir(os.path.dirname(self.config_path)):
+                    raise
 
         with open(self.template, "r") as tx:
             tx_s = tx.read().split("\n")

--- a/src/puzzle2/pz_config.py
+++ b/src/puzzle2/pz_config.py
@@ -38,8 +38,12 @@ def save(path, data, tool_name="", category="", version=""):
     :param version:  info
     :return:  bool
     """
-    if not os.path.exists(os.path.dirname(path)):
-        os.makedirs(os.path.dirname(path))
+    if not os.path.isdir(os.path.dirname(path)):
+        try:
+            os.makedirs(os.path.dirname(path))
+        except BaseException:  # Dir is created between the os.path.isdir and the os.makedirs calls
+            if not os.path.isdir(os.path.dirname(path)):
+                raise
 
     info_data = {"info": {"name": tool_name,
                           "category": category,

--- a/src/puzzle2/pz_env.py
+++ b/src/puzzle2/pz_env.py
@@ -29,8 +29,12 @@ def get_log_template():
 
 def get_temp_directory(subdir=""):
     path = "%s/%s" % (TEMP_PATH, subdir)
-    if not os.path.exists(path):
-        os.makedirs(path)
+    if not os.path.isdir(path):
+        try:
+            os.makedirs(path)
+        except BaseException:  # Dir is created between the os.path.isdir and the os.makedirs calls
+            if not os.path.isdir(path):
+                raise
     if path.endswith("/"):
         path = path[:-1]
     return path
@@ -45,12 +49,15 @@ def get_user_name():
         return os.environ["PUZZLE_USERNAME"]
     return os.environ.get("USERNAME", "unknown")
 
+
 def get_python_version():
     version_info = sys.version_info
     return {"major": version_info.major, "minor": version_info.minor}
 
+
 def get_APP():
     return APP
+
 
 def get_env():
     env = {
@@ -58,13 +65,14 @@ def get_env():
         "_user_name_": get_user_name(),
         "_datetime_": datetime.datetime.now().strftime("%y/%m/%d %H:%M:%S"),
         "_os_": {"system": platform.system(),
-               "release": platform.release(),
-               "version": platform.version(),
-               "platform": platform.platform()},
+                 "release": platform.release(),
+                 "version": platform.version(),
+                 "platform": platform.platform()},
         "_python_version_": get_python_version()
 
     }
     return env
+
 
 if __name__ == "__main__":
     print(get_env())


### PR DESCRIPTION
修正内容: 
os.path.isdir()実行後、かつ os.makedirs() 実行前のタイミングで他プロセスが先に同フォルダを作成するケースがあると処理が止まってしまうので、修正しました。

例として、複数ファイルを同時バッチ実行した際に再現できます。