### PR TITLE
Fix/20230323 log template file to json

### DIFF
--- a/src/puzzle2/Puzzle.py
+++ b/src/puzzle2/Puzzle.py
@@ -49,7 +49,7 @@ class Puzzle(object):
         if "log_directory" in kwargs:
             del kwargs["log_directory"]
 
-        if not kwargs.get("logger", False):
+        if not isinstance(kwargs.get("logger", False), PzLog.PzLog):
             self.Log = PzLog.PzLog(name=self.name,
                                    log_directory=log_directory,
                                    **kwargs)

--- a/src/puzzle2/log.template.yml
+++ b/src/puzzle2/log.template.yml
@@ -1,0 +1,25 @@
+data:
+  disable_existing_loggers: false
+  formatters:
+    simple_formatter:
+      datefmt: '%m-%d-%y %H:%M:%S'
+      format: '%(asctime)-25s %(levelname)-10s %(module)-20s %(funcName)-25s line:%(lineno)-5s
+        %(message)s'
+  handlers:
+    file_handler:
+      class: logging.FileHandler
+      filename: logfile.log
+      formatter: simple_formatter
+      level: DEBUG
+      mode: a
+    stream_handler:
+      class: logging.StreamHandler
+      formatter: simple_formatter
+      level: DEBUG
+      stream: ext://sys.stdout
+
+  version: 1
+info:
+  category: ''
+  name: {}
+  version: ''

--- a/src/puzzle2/pz_env.py
+++ b/src/puzzle2/pz_env.py
@@ -39,7 +39,7 @@ def get_puzzle_module_path():
     return os.path.dirname(get_puzzle_path()).replace("\\", "/")
 
 def get_log_template():
-    return "{}/log.template".format(get_puzzle_path())
+    return "{}/log.template.yml".format(get_puzzle_path())
 
 def get_temp_directory(subdir=""):
     path = "%s/%s" % (TEMP_PATH, subdir)

--- a/tests/src/win/test_PzLog.py
+++ b/tests/src/win/test_PzLog.py
@@ -1,0 +1,166 @@
+import unittest
+import os
+import sys
+import logging
+
+sys.path.append(r"H:\projects\colorrd\repos\puzzle2\src")
+
+from puzzle2.PzLog import PzLog
+import puzzle2.pz_config as pz_config
+import unittest
+
+class PzLogUseDefaultTemplate(unittest.TestCase):
+    def setUp(self):
+        """
+        The 'reset_template' param always uses the default 'template.yml' file.
+        """
+        logging.Logger.manager.loggerDict.clear()
+        self.pz_log = PzLog("test", reset_template=True)
+    
+    def test_check_template(self):
+        self.assertEqual(os.path.basename(self.pz_log.base_template_path), "log.template.yml")
+        for handler in self.pz_log.logger.handlers:
+            if handler.name == "stream_handler":
+                self.assertEqual(handler.level, logging.DEBUG)
+    
+    def tearDown(self):
+        self.pz_log.remove_handlers()
+
+
+class PzLogUseExistsTemplate(unittest.TestCase):
+    def setUp(self):
+        """
+        create a default template logger.(pz_logA)
+        then change level for next logger, with have same name.
+        "new" param makes reflesh handlers.
+        pz_logB will read template file from pz_logA's template file.
+        but stream handler level will be changed to CRITICAL.
+        """
+        logging.Logger.manager.loggerDict.clear()
+
+        self.pz_logA = PzLog("test2")
+        info, config = pz_config.read(self.pz_logA.base_template_path)
+        config["handlers"]["stream_handler"]["level"] = "CRITICAL"
+        pz_config.save(self.pz_logA.base_template_path, config, {})
+
+        self.pz_logB = PzLog("test2", new=True, reset_template=False)
+
+    def test_check_template(self):
+        """
+        WARNING:
+           in ths case, pz_logA's stream handler level will be changed to WARNING too.
+           pz_logA and pz_logB have same logger object.
+        """
+
+        # check template file name.this is same as pz_logA's template file.
+        self.assertEqual(os.path.basename(self.pz_logB.base_template_path), "test2.json")
+
+        for handler in self.pz_logA.logger.handlers:
+            if handler.name == "stream_handler":
+                self.assertEqual(handler.level, logging.CRITICAL)
+
+        for handler in self.pz_logB.logger.handlers:
+            if handler.name == "stream_handler":
+                self.assertEqual(handler.level, logging.CRITICAL)
+
+    def tearDown(self):
+        self.pz_logA.remove_handlers()
+        self.pz_logB.remove_handlers()
+
+class PzLogUseExistsTemplateAddingDateToLogName(unittest.TestCase):
+    def setUp(self):
+        """
+        The "add_date_to_log_name" parameter creates a log file name that includes the date. 
+        If the day changes, a different date log will be used, based on the existing template file. 
+        In this case, the existing template file will not be used.
+        """
+        logging.Logger.manager.loggerDict.clear()
+        self.pz_logA = PzLog("test3", add_date_to_log_name=True)
+        self.pz_logB = PzLog("test3", new=True, reset_template=False, add_date_to_log_name=True)
+
+    def test_check_template(self):
+        """
+        simmilier to PzLogUseExistsTemplate but add_date_to_log_name is True.
+        so, default template.yml will be used.
+        """
+        self.assertEqual(os.path.basename(self.pz_logB.base_template_path), "log.template.yml")
+        for handler in self.pz_logB.logger.handlers:
+            if handler.name == "stream_handler":
+                self.assertEqual(handler.level, logging.DEBUG)
+
+    def tearDown(self):
+        self.pz_logA.remove_handlers()
+        self.pz_logB.remove_handlers()
+
+class PzLogUtility(unittest.TestCase):
+    def test_check_log_file_name(self):
+        logging.Logger.manager.loggerDict.clear()
+        self.pz_logA = PzLog("test1", add_date_to_log_name=True)
+        import datetime
+        now = datetime.datetime.now().strftime("%Y%m%d")
+        for handler in self.pz_logA.logger.handlers:
+            if handler.name == "file_handler":
+                self.assertEqual(os.path.basename(handler.baseFilename), "{}_test1.log".format(now))
+
+    def test_check_log_file_name02(self):
+        logging.Logger.manager.loggerDict.clear()
+        self.pz_logA = PzLog("test1", add_date_to_log_name=True, user_name="name")
+        import datetime
+        now = datetime.datetime.now().strftime("%Y%m%d")
+        for handler in self.pz_logA.logger.handlers:
+            if handler.name == "file_handler":
+                self.assertEqual(os.path.basename(handler.baseFilename), "{}_test1_name.log".format(now))
+
+    def test_update_level(self):
+        logging.Logger.manager.loggerDict.clear()
+        self.pz_logA = PzLog("test4", file_handler_level="CRITICAL", stream_handler_level="CRITICAL")
+
+        for handler in self.pz_logA.logger.handlers:
+            self.assertEqual(handler.level, logging.CRITICAL)
+        
+    def tearDown(self):
+        self.pz_logA.remove_handlers()
+
+class PzLogDetail(unittest.TestCase):
+    def setUp(self):
+        self.pz_logA = PzLog("test5")
+        self.logger = self.pz_logA.logger
+    
+    def test_add_details(self):
+        self.logger.details.set_name("task_name1")
+        name1 = self.logger.details.name
+
+        self.logger.details.add_detail("test1")
+        self.logger.details.add_detail("test2")
+        self.logger.details.add_detail("test3")
+        self.logger.details.set_header(0, "first task")
+
+        self.logger.details.set_name("task_name2")
+        name2 = self.logger.details.name
+        self.logger.details.add_detail("test4")
+        self.logger.details.add_detail("test5")
+        self.logger.details.add_detail("test6")
+        self.logger.details.set_header(1, "secound task") 
+
+        self.assertEqual(self.logger.details.get_details(name1), ["test1", "test2", "test3"])
+        self.assertEqual(self.logger.details.get_details(name2), ["test4", "test5", "test6"])
+
+        self.assertEqual(self.logger.details.get_details(), [["test1", "test2", "test3"], 
+                                                             ["test4", "test5", "test6"]])
+        
+        self.assertEqual(self.logger.details.get_return_codes(), [0, 1])
+
+        self.assertEqual(self.logger.details.get_all(), [{"return_code": 0, "header": "first task", "details": ["test1", "test2", "test3"]},
+                                                         {"return_code": 1, "header": "secound task", "details": ["test4", "test5", "test6"]}])
+
+
+        self.logger.details.clear()
+       
+        self.assertEqual(self.logger.details.get_header(), [])
+        self.assertEqual(self.logger.details.get_details(), [])
+
+    def tearDown(self):
+        self.pz_logA.remove_handlers()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/src/win/test_PzLog.py
+++ b/tests/src/win/test_PzLog.py
@@ -3,7 +3,6 @@ import os
 import sys
 import logging
 
-sys.path.append(r"H:\projects\colorrd\repos\puzzle2\src")
 
 from puzzle2.PzLog import PzLog
 import puzzle2.pz_config as pz_config


### PR DESCRIPTION
@Narimation 

PzLogでiniファイルを使用していたところをdictConfigに変更しました。
その際にコード、引数の整理、loggerの名前にpuzzleのnamespaceを追加しています。

pyBatcher側でtemplate等カスタマイズしていると思いますが
問題ないかご確認お願いいたします。

また`logging.setLoggerClass(PzLogger)`ここが気になっています。
PzLoggerを読んだ後にGetLoggerをするとPzLoggerになってしまうのは自分たちは
ただの拡張だと把握していますが他の人はどう思うか、と。
特にmayaでpuzzleを使った後に他のツールでGetLoggerしたらPzLoggerが呼ばれるので
気になる人は気にしそうです。
